### PR TITLE
Fixing branched from tests

### DIFF
--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -501,6 +501,12 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
                     'registration_metadata': registration_metadata
                 },
                 'relationships': {
+                    'branched_from': {
+                        'data': {
+                            'type': 'nodes',
+                            'id': project_public._id,
+                        }
+                    },
                     'registration_schema': {
                         'data': {
                             'type': 'registration_schema',


### PR DESCRIPTION
Tests did not have 'branched_from' specified in the payload and therefore failed.