### PR TITLE
Fixing self links in draft registration endpoint

### DIFF
--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -46,7 +46,7 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
     node_license = NodeLicenseSerializer(required=False, source='license')
 
     links = LinksField({
-        'self': 'get_self_url',
+        'self': 'get_absolute_url',
     })
 
     affiliated_institutions = RelationshipField(
@@ -99,6 +99,8 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
                 'version': self.context['request'].parser_context['kwargs']['version'],
             },
         )
+    def get_absolute_url(self, obj):
+        return obj.get_absolute_url()
 
     # Overrides DraftRegistrationLegacySerializer
     def get_node(self, validated_data):

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -667,6 +667,14 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         self._metaschema_flags.update(flags)
 
     @property
+    def branched_from_type(self):
+        if type(self.branched_from) == DraftNode:
+            return 'DraftNode'
+        elif type(self.branched_from) == Node:
+            return 'Node'
+        return ''
+
+    @property
     def url(self):
         return self.URL_TEMPLATE.format(
             node_id=self.branched_from._id,
@@ -685,7 +693,11 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
     def absolute_api_v2_url(self):
         # Old draft registration URL - user new endpoints, through draft registration
         node = self.branched_from
-        path = '/nodes/{}/draft_registrations/{}/'.format(node._id, self._id)
+        branched_type = self.branched_from_type
+        if branched_type == 'DraftNode':
+            path = '/draft_registrations/{}/'.format(self._id)
+        elif branched_type == 'Node':
+            path = '/nodes/{}/draft_registrations/{}/'.format(node._id, self._id)
         return api_v2_url(path)
 
     # used by django and DRF


### PR DESCRIPTION
`self` links in the draft_registration endpoint were not properly displaying. This has been fixed, as well as making the self links conditional based on whether the draft registration is branched from a node or draftnode. 

In addition, a draft registration property has been added to tell whether the registration is branched from a draft node or a node.